### PR TITLE
Fix linting issues for API go module

### DIFF
--- a/api/common/constants/constants.go
+++ b/api/common/constants/constants.go
@@ -24,7 +24,7 @@ const (
 
 const (
 	// AnnotationEnableScalingDiagnostics is the annotation key to enable scaling diagnostics for a cluster.
-	// This is applied by a user/tool on the ClusterScalingConstraint object which produces diagnostics withing
+	// This is applied by a user/tool on the ClusterScalingConstraint object which produces diagnostics within
 	// the generated ClusterScalingAdvice.Status.
 	AnnotationEnableScalingDiagnostics = "sa.gardener.cloud/enable-scaling-diagnostics"
 )
@@ -45,10 +45,16 @@ const (
 )
 
 const (
-	DefaultOperatorServerPort      = 8080
+	// DefaultOperatorServerPort is the default port for the scaling advisor operator server.
+	DefaultOperatorServerPort = 8080
+	// DefaultOperatorHealthProbePort is the default port for the operator health probe endpoints.
 	DefaultOperatorHealthProbePort = 8081
-	DefaultOperatorMetricsPort     = 8082
-	DefaultOperatorProfilingPort   = 8083
-	DefaultAdvisorServicePort      = 8090
-	DefaultMinKAPIPort             = 8091
+	// DefaultOperatorMetricsPort is the default port for the operator metrics endpoint.
+	DefaultOperatorMetricsPort = 8082
+	// DefaultOperatorProfilingPort is the default port for the operator profiling endpoints.
+	DefaultOperatorProfilingPort = 8083
+	// DefaultAdvisorServicePort is the default port for the scaling advisor service.
+	DefaultAdvisorServicePort = 8090
+	// DefaultMinKAPIPort is the default port for the MinKAPI service.
+	DefaultMinKAPIPort = 8091
 )

--- a/api/common/errors/errors.go
+++ b/api/common/errors/errors.go
@@ -16,7 +16,6 @@ var (
 	ErrInvalidOptVal = errors.New("invalid option value")
 	// ErrUnimplemented indicates that the feature or operation is unimplemented. It possibly maybe be implemented in the future.
 	ErrUnimplemented = errors.New("not implemented")
-
 	// ErrUnexpectedType is a sentinel error representing an unexpected type error which should not happen - generally encountered when casting. Use this in lieu of a panic.
 	ErrUnexpectedType = errors.New("unexpected type")
 )

--- a/api/common/types/types.go
+++ b/api/common/types/types.go
@@ -20,7 +20,6 @@ type Service interface {
 	// Start starts the service with the given context. Start may block depending on the implementation - if the service is a server.
 	// The context is expected to be populated with a logger.
 	Start(ctx context.Context) error
-
 	// Stop stops the service. Stop does not block.
 	Stop(ctx context.Context) error
 }
@@ -30,7 +29,7 @@ type ServerConfig struct {
 	HostPort `json:",inline"`
 	// KubeConfigPath is the path to master kube-config.
 	KubeConfigPath string `json:"kubeConfigPath"`
-	// ProfilingEnable indicates whether this service should register the standard pprof HTTP handlers: /debug/pprof/*
+	// ProfilingEnabled indicates whether this service should register the standard pprof HTTP handlers: /debug/pprof/*
 	ProfilingEnabled bool `json:"profilingEnabled"`
 	// GracefulShutdownTimeout is the time given to the service to gracefully shutdown.
 	GracefulShutdownTimeout metav1.Duration `json:"gracefulShutdownTimeout"`
@@ -46,8 +45,10 @@ type HostPort struct {
 
 // QPSBurst is a simple encapsulation of client QPS and Burst settings.
 type QPSBurst struct {
-	QPS   float32 `json:"qps"`
-	Burst int     `json:"burst"`
+	// QPS is the queries per second rate limit for the client.
+	QPS float32 `json:"qps"`
+	// Burst is the burst size for rate limiting, allowing temporary spikes above QPS.
+	Burst int `json:"burst"`
 }
 
 // ConstraintReference is a reference to the ClusterScalingConstraint for which this advice is generated.
@@ -62,20 +63,30 @@ type ConstraintReference struct {
 type NodeScoringStrategy string
 
 const (
+	// LeastWasteNodeScoringStrategy represents a scoring strategy that minimizes resource waste.
 	LeastWasteNodeScoringStrategy NodeScoringStrategy = "LeastWaste"
-	LeastCostNodeScoringStrategy  NodeScoringStrategy = "LeastCost"
+	// LeastCostNodeScoringStrategy represents a scoring strategy that minimizes cost.
+	LeastCostNodeScoringStrategy NodeScoringStrategy = "LeastCost"
 )
 
+// CloudProvider represents the cloud provider type for the cluster.
 type CloudProvider string
 
 const (
-	AWSCloudProvider       CloudProvider = "aws"
-	GCPCloudProvider       CloudProvider = "gcp"
-	AzureCloudProvider     CloudProvider = "azure"
-	AliCloudProvider       CloudProvider = "ali"
+	// AWSCloudProvider indicates AWS as cloud provider.
+	AWSCloudProvider CloudProvider = "aws"
+	// GCPCloudProvider indicates GCP as cloud provider.
+	GCPCloudProvider CloudProvider = "gcp"
+	// AzureCloudProvider indicates Azure as cloud provider.
+	AzureCloudProvider CloudProvider = "azure"
+	// AliCloudProvider indicates Alibaba Cloud as cloud provider.
+	AliCloudProvider CloudProvider = "ali"
+	// OpenStackCloudProvider indicates OpenStack as cloud provider.
 	OpenStackCloudProvider CloudProvider = "openstack"
 )
 
+// AsCloudProvider converts a string to CloudProvider type. It returns an error if the cloudProvider string
+// is not supported.
 func AsCloudProvider(cloudProvider string) (CloudProvider, error) {
 	switch cloudProvider {
 	case "aws":
@@ -97,15 +108,23 @@ func AsCloudProvider(cloudProvider string) (CloudProvider, error) {
 type ClientAccessMode string
 
 const (
-	ClientAccessNetwork  ClientAccessMode = "Network"
+	// ClientAccessNetwork indicates the client accesses k8s api-server via a network call.
+	ClientAccessNetwork ClientAccessMode = "Network"
+	// ClientAccessInMemory indicates the client accesses k8s api-server via in-memory calls by passing network calls
+	// thus reducing the need for serialization and deserialization of requests and responses.
 	ClientAccessInMemory ClientAccessMode = "InMemory"
 )
 
-// ClientFacades is a holder for the primary k8s client and informer interfaces
+// ClientFacades is a holder for the primary k8s client and informer interfaces.
 type ClientFacades struct {
-	Mode               ClientAccessMode
-	Client             kubernetes.Interface
-	DynClient          dynamic.Interface
-	InformerFactory    informers.SharedInformerFactory
+	// Mode indicates the access mode of the Kubernetes client.
+	Mode ClientAccessMode
+	// Client is the standard Kubernetes clientset for accessing core APIs.
+	Client kubernetes.Interface
+	// DynClient is the dynamic client for accessing arbitrary Kubernetes resources.
+	DynClient dynamic.Interface
+	// InformerFactory provides shared informers for core Kubernetes resources.
+	InformerFactory informers.SharedInformerFactory
+	// DynInformerFactory provides shared informers for dynamic Kubernetes resources.
 	DynInformerFactory dynamicinformer.DynamicSharedInformerFactory
 }

--- a/api/config/v1alpha1/types.go
+++ b/api/config/v1alpha1/types.go
@@ -93,7 +93,9 @@ type ControllersConfiguration struct {
 // ScalingConstraintsControllerConfiguration is the configuration for then controller that reconciles ScalingConstraints.
 type ScalingConstraintsControllerConfiguration struct {
 	// ConcurrentSyncs is the maximum number concurrent reconciliations that can be run for this controller.
-	ConcurrentSyncs *int                            `json:"concurrentSyncs"`
+	ConcurrentSyncs *int `json:"concurrentSyncs"`
+	// ScoringStrategy defines the node scoring strategy to use for scaling decisions.
 	ScoringStrategy commontypes.NodeScoringStrategy `json:"scoringStrategy"`
-	CloudProvider   commontypes.CloudProvider       `json:"cloudProvider"`
+	// CloudProvider specifies the cloud provider for which the scaling advisor is configured.
+	CloudProvider commontypes.CloudProvider `json:"cloudProvider"`
 }

--- a/api/config/v1alpha1/validation/validation.go
+++ b/api/config/v1alpha1/validation/validation.go
@@ -20,6 +20,7 @@ func ValidateScalingAdvisorConfiguration(config *configv1apha1.ScalingAdvisorCon
 	return allErrs
 }
 
+// validateClientConnectionConfiguration validates the client connection configuration.
 func validateClientConnectionConfiguration(config configv1apha1.ClientConnectionConfiguration, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	if config.Burst < 0 {
@@ -28,6 +29,7 @@ func validateClientConnectionConfiguration(config configv1apha1.ClientConnection
 	return allErrs
 }
 
+// validateLeaderElectionConfiguration validates the leader election configuration.
 func validateLeaderElectionConfiguration(config configv1apha1.LeaderElectionConfiguration, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if !config.Enabled {
@@ -51,6 +53,7 @@ func validateLeaderElectionConfiguration(config configv1apha1.LeaderElectionConf
 	return allErrs
 }
 
+// mustBeGreaterThanZeroDuration validates that a duration is greater than zero.
 func mustBeGreaterThanZeroDuration(duration metav1.Duration, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if duration.Duration <= 0 {

--- a/api/core/v1alpha1/crds/sa.gardener.cloud_clusterscalingadvices.yaml
+++ b/api/core/v1alpha1/crds/sa.gardener.cloud_clusterscalingadvices.yaml
@@ -63,6 +63,8 @@ spec:
                     description: Items is the slice of scaling-in advice for a node
                       pool.
                     items:
+                      description: ScaleInItem is the unit of scaling-in advice for
+                        a specific node.
                       properties:
                         availabilityZone:
                           description: AvailabilityZone is the availability zone of

--- a/api/core/v1alpha1/scalingadvice.go
+++ b/api/core/v1alpha1/scalingadvice.go
@@ -72,6 +72,7 @@ type ScaleInPlan struct {
 	Items []ScaleInItem `json:"items"`
 }
 
+// ScaleInItem is the unit of scaling-in advice for a specific node.
 type ScaleInItem struct {
 	NodePlacement `json:",inline"`
 	// NodeName is the name of the node to be scaled in.

--- a/api/minkapi/errors.go
+++ b/api/minkapi/errors.go
@@ -11,21 +11,30 @@ import (
 )
 
 var (
+	// ErrInitFailed is a sentinel error indicating that the minkapi program failed to initialize.
 	ErrInitFailed = fmt.Errorf(commonerrors.FmtInitFailed, ProgramName)
 	// ErrStartFailed is a sentinel error indicating that the service failed to start.
-	ErrStartFailed         = fmt.Errorf(commonerrors.FmtStartFailed, ProgramName)
+	ErrStartFailed = fmt.Errorf(commonerrors.FmtStartFailed, ProgramName)
+	// ErrClientFacadesFailed is a sentinel error indicating that client facades creation failed.
 	ErrClientFacadesFailed = errors.New("failed to create client facades")
 	// ErrServiceFailed is a sentinel error indicating that the service failed.
-	ErrServiceFailed         = fmt.Errorf("%s service failed", ProgramName)
-	ErrLoadConfigTemplate    = errors.New("cannot load config template")
+	ErrServiceFailed = fmt.Errorf("%s service failed", ProgramName)
+	// ErrLoadConfigTemplate is a sentinel error indicating that config template loading failed.
+	ErrLoadConfigTemplate = errors.New("cannot load config template")
+	// ErrExecuteConfigTemplate is a sentinel error indicating that config template execution failed.
 	ErrExecuteConfigTemplate = errors.New("cannot execute config template")
-	ErrStoreNotFound         = errors.New("store not found")
-	ErrCreateWatcher         = errors.New("cannot create watcher")
-	ErrCreateObject          = errors.New("cannot create object")
-	ErrDeleteObject          = errors.New("cannot delete object")
-	ErrListObjects           = errors.New("cannot list objects")
-
+	// ErrStoreNotFound is a sentinel error indicating that a resource store was not found.
+	ErrStoreNotFound = errors.New("store not found")
+	// ErrCreateWatcher is a sentinel error indicating that watcher creation failed.
+	ErrCreateWatcher = errors.New("cannot create watcher")
+	// ErrCreateObject is a sentinel error indicating that object creation failed.
+	ErrCreateObject = errors.New("cannot create object")
+	// ErrDeleteObject is a sentinel error indicating that object deletion failed.
+	ErrDeleteObject = errors.New("cannot delete object")
+	// ErrListObjects is a sentinel error indicating that object listing failed.
+	ErrListObjects = errors.New("cannot list objects")
+	// ErrUpdateObject is a sentinel error indicating that object update failed.
 	ErrUpdateObject = errors.New("cannot update object")
-
+	// ErrCreateSandbox is a sentinel error indicating that sandbox creation failed.
 	ErrCreateSandbox = errors.New("cannot create sandbox")
 )

--- a/api/minkapi/types.go
+++ b/api/minkapi/types.go
@@ -27,9 +27,11 @@ import (
 
 const (
 	// ProgramName is the name of the program.
-	ProgramName           = "minkapi"
+	ProgramName = "minkapi"
+	// DefaultWatchQueueSize is the default maximum number of events to queue per watcher.
 	DefaultWatchQueueSize = 100
-	DefaultWatchTimeout   = 5 * time.Minute
+	// DefaultWatchTimeout is the default timeout for watches after which MinKAPI service closes the connection.
+	DefaultWatchTimeout = 5 * time.Minute
 	// DefaultKubeConfigPath is the default kubeconfig path if none is specified.
 	DefaultKubeConfigPath = "/tmp/minkapi.yaml"
 	// DefaultBasePrefix is the default path prefix for the base minkapi server
@@ -50,60 +52,75 @@ type Config struct {
 	// Defaults to [DefaultBasePrefix]
 	BasePrefix string
 	commontypes.ServerConfig
+	// WatchConfig holds config parameters relevant for watchers.
 	WatchConfig WatchConfig
 }
 
 // Resettable defines types that can reset their state to a default or initial configuration.
 type Resettable interface {
+	// Reset resets the state of the implementing type.
 	Reset()
 }
 
+// WatchEventCallback is a function type for handling watch events from a ResourceStore.
 type WatchEventCallback func(watch.Event) (err error)
 
+// ResourceStore defines an interface for storing and managing Kubernetes resources with watch capabilities.
 type ResourceStore interface {
 	Resettable
 	io.Closer
 	// GetObjAndListGVK gets the object GVK and object list GVK associated with this resource store.
 	GetObjAndListGVK() (objKind schema.GroupVersionKind, objListKind schema.GroupVersionKind)
-
+	// Add adds a new object to the store.
 	Add(mo metav1.Object) error
+	// GetByKey retrieves an object from the store by its key.
 	GetByKey(key string) (o runtime.Object, err error)
+	// Get retrieves an object from the store by its name.
 	Get(objName cache.ObjectName) (o runtime.Object, err error)
+	// Update updates an existing object in the store.
 	Update(mo metav1.Object) error
+	// DeleteByKey deletes an object from the store by its key.
 	DeleteByKey(key string) error
+	// Delete deletes an object from the store by its name.
 	Delete(objName cache.ObjectName) error
-
+	// DeleteObjects deletes objects matching the given criteria and returns the count of deleted objects.
 	DeleteObjects(c MatchCriteria) (delCount int, err error)
+	// List lists objects matching the given criteria.
 	List(c MatchCriteria) (listObj runtime.Object, err error)
-
+	// ListMetaObjects lists metadata objects matching the given criteria.
 	ListMetaObjects(c MatchCriteria) (metaObjs []metav1.Object, maxVersion int64, err error)
-
 	// Watch watches object changes in this store starting from the given startVersion, belonging to the given namespace and matching the given labelSelector and then constructs a watch.Event followed by invoking eventCallback.
 	Watch(ctx context.Context, startVersion int64, namespace string, labelSelector labels.Selector, eventCallback WatchEventCallback) error
-
 	// GetWatcher returns a watcher - an implementation of watch.Interface to watch changes in objects beginning from options.ResourceVersion and belonging to the given namespace, then use the  options.labelSelector to filter, and supply watch events via the watch.Interface.ResultChan.
 	// options.FieldSelector is currently not supported.
 	GetWatcher(ctx context.Context, namespace string, options metav1.ListOptions) (watch.Interface, error)
-
 	// GetVersionCounter returns the atomic counter for generating monotonically increasing resource versions
 	GetVersionCounter() *atomic.Int64
 }
 
+// ResourceStoreArgs contains arguments for creating a ResourceStore.
 type ResourceStoreArgs struct {
-	Name          string
-	ObjectGVK     schema.GroupVersionKind
+	// Name is the name of the resource store.
+	Name string
+	// ObjectGVK is the GroupVersionKind for objects stored in this store.
+	ObjectGVK schema.GroupVersionKind
+	// ObjectListGVK is the GroupVersionKind for object lists from this store.
 	ObjectListGVK schema.GroupVersionKind
 	// Scheme is the runtime Scheme used by the KAPI objects storable in this store.
-	Scheme      *runtime.Scheme
+	Scheme *runtime.Scheme
+	// WatchConfig contains configuration for watch operations.
 	WatchConfig WatchConfig
 	// VersionCounter is the atomic counter for generating monotonically increasing resource versions
 	VersionCounter *atomic.Int64 //optional
-	Log            logr.Logger
+	// Log is the logger instance for this store.
+	Log logr.Logger
 }
 
+// EventSink defines an interface for storing and retrieving Kubernetes events.
 type EventSink interface {
 	Resettable
 	events.EventSink
+	// List returns all events in the sink.
 	List() []eventsv1.Event
 }
 
@@ -112,52 +129,76 @@ type EventSink interface {
 type View interface {
 	Resettable
 	io.Closer
+	// GetName returns the name of this view.
 	GetName() string
+	// GetType returns the type of this view (base or sandbox).
 	GetType() ViewType
 	// GetClientFacades gets the in-memory implementation ClientFacades that can be used by code to interact with this view
 	// via standard k8s client and informer interfaces
 	GetClientFacades() (commontypes.ClientFacades, error)
+	// GetResourceStore returns the resource store for the specified GroupVersionKind.
 	GetResourceStore(gvk schema.GroupVersionKind) (ResourceStore, error)
+	// GetEventSink returns the event sink for this view.
 	GetEventSink() EventSink
+	// CreateObject creates a new object of the specified GVK in this view.
 	CreateObject(gvk schema.GroupVersionKind, obj metav1.Object) error
+	// GetObject retrieves an object of the specified GVK by name.
 	GetObject(gvk schema.GroupVersionKind, objName cache.ObjectName) (runtime.Object, error)
+	// UpdateObject updates an existing object of the specified GVK.
 	UpdateObject(gvk schema.GroupVersionKind, obj metav1.Object) error
+	// UpdatePodNodeBinding updates a pod's node binding and returns the updated pod.
 	UpdatePodNodeBinding(podName cache.ObjectName, binding corev1.Binding) (*corev1.Pod, error)
+	// PatchObject applies a patch to an object of the specified GVK.
 	PatchObject(gvk schema.GroupVersionKind, objName cache.ObjectName, patchType types.PatchType, patchData []byte) (patchedObj runtime.Object, err error)
+	// PatchObjectStatus applies a patch to an object's status subresource.
 	PatchObjectStatus(gvk schema.GroupVersionKind, objName cache.ObjectName, patchData []byte) (patchedObj runtime.Object, err error)
+	// ListMetaObjects lists metadata objects matching the given criteria.
 	ListMetaObjects(gvk schema.GroupVersionKind, criteria MatchCriteria) (metaObjs []metav1.Object, maxVersion int64, err error)
 	// ListObjects lists objects in the store while matching the criteria and returns the matching objects as a runtime.Object which is actually a *<Kind>List. Ex: *PodList
 	// TODO: consider better name for this method.
 	ListObjects(gvk schema.GroupVersionKind, criteria MatchCriteria) (runtime.Object, error)
+	// WatchObjects watches for changes to objects of the specified GVK.
 	WatchObjects(ctx context.Context, gvk schema.GroupVersionKind, startVersion int64, namespace string, labelSelector labels.Selector, eventCallback WatchEventCallback) error
+	// GetWatcher returns a watcher for objects of the specified GVK.
 	GetWatcher(ctx context.Context, gvk schema.GroupVersionKind, namespace string, opts metav1.ListOptions) (watch.Interface, error)
+	// DeleteObject deletes an object of the specified GVK by name.
 	DeleteObject(gvk schema.GroupVersionKind, objName cache.ObjectName) error
+	// DeleteObjects deletes objects of the specified GVK matching the criteria.
 	DeleteObjects(gvk schema.GroupVersionKind, criteria MatchCriteria) error
+	// ListNodes returns nodes matching the specified node names, or all nodes if none specified.
 	ListNodes(matchingNodeNames ...string) ([]corev1.Node, error)
+	// ListPods returns pods matching the specified criteria.
 	ListPods(criteria MatchCriteria) ([]corev1.Pod, error)
+	// ListEvents returns events in the specified namespace.
 	ListEvents(namespace string) ([]eventsv1.Event, error)
 	// GetObjectChangeCount returns the current change count made to objects through this view.
 	GetObjectChangeCount() int64
+	// GetKubeConfigPath returns the path to the kubeconfig file for this view.
 	GetKubeConfigPath() string
 }
 
+// ViewType represents the type of View.
 type ViewType string
 
 const (
-	BaseViewType    ViewType = "base"
+	// BaseViewType represents the foundational view of the MinKAPI server.
+	BaseViewType ViewType = "base"
+	// SandboxViewType represents a sandboxed private view.
 	SandboxViewType ViewType = "sandbox"
 )
 
 // CreateSandboxViewFunc represents a creator function for constructing sandbox views from the delegate view and given args
 type CreateSandboxViewFunc = func(log logr.Logger, delegateView View, args *ViewArgs) (View, error)
 
+// ViewArgs contains arguments for creating a View.
 type ViewArgs struct {
 	// Name represents name of View
 	Name string
 	// KubeConfigPath is the path of the kubeconfig file corresponding to this view
 	KubeConfigPath string
 	// Scheme is the runtime Scheme used by KAPI objects exposed by this view
-	Scheme      *runtime.Scheme
+	Scheme *runtime.Scheme
+	// WatchConfig contains configuration for watch operations.
 	WatchConfig WatchConfig
 }
 
@@ -176,23 +217,30 @@ type Server interface {
 }
 
 // App represents an application process that wraps a minkapi Server, an application context and application cancel func.
-//
-// `main` entry-point functions taht embed minkapi are expected to construct a new App instance via cli.LaunchApp and shutdown applications via cli.ShutdownApp
+// Main entry-point functions that embed minkapi are expected to construct a new App instance via cli.LaunchApp and shutdown applications via cli.ShutdownApp
 type App struct {
+	// Server is the MinKAPI server instance.
 	Server Server
-	Ctx    context.Context
+	// Ctx is the application context.
+	Ctx context.Context
+	// Cancel is the context cancellation function.
 	Cancel context.CancelFunc
 }
 
+// MatchCriteria defines criteria for matching Kubernetes objects.
 type MatchCriteria struct {
+	// Namespace specifies the namespace to match. Empty means all namespaces.
 	Namespace string
-	Names     sets.Set[string]
-	// Labels        map[string]string
+	// Names specifies the set of object names to match. Empty means all names.
+	Names sets.Set[string]
+	// LabelSelector specifies the label selector for matching objects.
 	LabelSelector labels.Selector
 }
 
+// MatchAllCriteria is a predefined criteria that matches all objects.
 var MatchAllCriteria = MatchCriteria{}
 
+// Matches returns true if the given object matches the criteria.
 func (c MatchCriteria) Matches(obj metav1.Object) bool {
 	if c.Namespace != "" && obj.GetNamespace() != c.Namespace {
 		return false

--- a/api/service/errors.go
+++ b/api/service/errors.go
@@ -23,29 +23,33 @@ var (
 	ErrRunSimulation = errors.New("failed to run simulation")
 	// ErrRunSimulationGroup is a sentinel error indicating that a scaling simulation group failed
 	ErrRunSimulationGroup = errors.New("failed to run simulation group")
-
 	// ErrSimulationTimeout is a sentinel error indicating that the simulation timed out
 	ErrSimulationTimeout = errors.New("simulation timed out")
-	//ErrComputeNodeScore is a sentinel error indicating that the NodeScorer failed to compute a score
+	// ErrComputeNodeScore is a sentinel error indicating that the NodeScorer failed to compute a score
 	ErrComputeNodeScore = errors.New("failed to compute node score")
 	// ErrNoWinningNodeScore is a sentinel error indicating that there is no winning NodeScore
 	ErrNoWinningNodeScore = errors.New("no winning node score")
-	//ErrSelectNodeScore is a sentinel error indicating that the NodeScoreSelector failed to select a score
+	// ErrSelectNodeScore is a sentinel error indicating that the NodeScoreSelector failed to select a score
 	ErrSelectNodeScore = errors.New("failed to select node score")
 	// ErrLoadSchedulerConfig is a sentinel error indicating that the service failed to load the scheduler configuration.
 	ErrLoadSchedulerConfig = errors.New("failed to load scheduler configuration")
 	// ErrLaunchScheduler is a sentinel error indicating that the service failed to launch the scheduler.
 	ErrLaunchScheduler = errors.New("failed to launch scheduler")
 	// ErrNoUnscheduledPods is a sentinel error indicating that the service was wrongly invoked with no unscheduled pods.
-	ErrNoUnscheduledPods              = errors.New("no unscheduled pods")
-	ErrNoScalingAdvice                = errors.New("no scaling advice")
+	ErrNoUnscheduledPods = errors.New("no unscheduled pods")
+	// ErrNoScalingAdvice is a sentinel error indicating that no scaling advice was generated.
+	ErrNoScalingAdvice = errors.New("no scaling advice")
+	// ErrUnsupportedNodeScoringStrategy is a sentinel error indicating an unsupported node scoring strategy was specified.
 	ErrUnsupportedNodeScoringStrategy = errors.New("unsupported node scoring strategy")
-	ErrUnsupportedCloudProvider       = errors.New("unsupported cloud provider")
-
+	// ErrUnsupportedCloudProvider is a sentinel error indicating an unsupported cloud provider was specified.
+	ErrUnsupportedCloudProvider = errors.New("unsupported cloud provider")
+	// ErrLoadInstanceTypeInfo is a sentinel error indicating that instance type information could not be loaded.
 	ErrLoadInstanceTypeInfo = errors.New("cannot load provider instance type info")
+	// ErrMissingRequiredLabel is a sentinel error indicating that a required label is missing from a resource.
 	ErrMissingRequiredLabel = errors.New("missing required label")
 )
 
+// AsGenerateError wraps an error with scaling advice request context information.
 func AsGenerateError(id string, correlationID string, err error) error {
 	if err == nil {
 		return nil

--- a/docs/api-reference/scaling-advisor-api.md
+++ b/docs/api-reference/scaling-advisor-api.md
@@ -85,7 +85,7 @@ _Appears in:_
 | `host` _string_ | Host is the IP address on which to listen for the specified port. |  |  |
 | `port` _integer_ | Port is the port on which to serve requests. |  |  |
 | `kubeConfigPath` _string_ | KubeConfigPath is the path to master kube-config. |  |  |
-| `profilingEnabled` _boolean_ | ProfilingEnable indicates whether this service should register the standard pprof HTTP handlers: /debug/pprof/* |  |  |
+| `profilingEnabled` _boolean_ | ProfilingEnabled indicates whether this service should register the standard pprof HTTP handlers: /debug/pprof/* |  |  |
 | `gracefulShutdownTimeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#duration-v1-meta)_ | GracefulShutdownTimeout is the time given to the service to gracefully shutdown. |  |  |
 | `healthProbes` _[HostPort](#hostport)_ | HealthProbes is the host and port for serving the healthz and readyz endpoints. |  |  |
 | `metrics` _[HostPort](#hostport)_ | Metrics is the host and port for serving the metrics endpoint. |  |  |
@@ -106,8 +106,8 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `concurrentSyncs` _integer_ | ConcurrentSyncs is the maximum number concurrent reconciliations that can be run for this controller. |  |  |
-| `scoringStrategy` _[NodeScoringStrategy](#nodescoringstrategy)_ |  |  |  |
-| `cloudProvider` _[CloudProvider](#cloudprovider)_ |  |  |  |
+| `scoringStrategy` _[NodeScoringStrategy](#nodescoringstrategy)_ | ScoringStrategy defines the node scoring strategy to use for scaling decisions. |  |  |
+| `cloudProvider` _[CloudProvider](#cloudprovider)_ | CloudProvider specifies the cloud provider for which the scaling advisor is configured. |  |  |
 
 
 
@@ -374,7 +374,7 @@ _Appears in:_
 
 
 
-
+ScaleInItem is the unit of scaling-in advice for a specific node.
 
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
* Adds doc strings for all exposed types and fields in the API go module.
* Fixes linting issues for the API go module highlighted by golangci-lint.

**NOTE:** 
1) This PR will not fix the linting sast issues in other go modules.
2) Claude was used to generate the documentation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
None
```
