### PR TITLE
Add privacy notice to pr and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,6 +5,8 @@ labels: kind/bug
 
 ---
 
+<!-- Please ensure that you do not include company internal information. -->
+
 **What happened**:
 
 **What you expected to happen**:

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -5,6 +5,8 @@ labels: kind/enhancement
 
 ---
 
+<!-- Please ensure that you do not include company internal information. -->
+
 **What would you like to be added**:
 
 **Why is this needed**:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+<!-- Please ensure that you do not include company internal information. -->
+
 **How to categorize this issue?**
 <!--
 Please select area, kind, and priority for this issue. This helps the community categorizing it.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- Please ensure that you do not include company internal information. -->
+
 **What this PR does / why we need it**:
 
 **Which issue(s) this PR fixes**:


### PR DESCRIPTION
This PR adds a privacy notice to pr and issue template files to remind users not to include company internal information.

Files modified:
- .github/ISSUE_TEMPLATE/bug_report.md
- .github/ISSUE_TEMPLATE/enhancement_request.md
- .github/ISSUE_TEMPLATE/feature_request.md
- .github/pull_request_template.md