### PR TITLE
Rename reviewed/ok-to-test to ok-to-test

### DIFF
--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'reviewed/ok-to-test' }}
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'ok-to-test' }}
     uses: ./.github/workflows/build.yaml
     with:
       mode: snapshot
@@ -21,7 +21,7 @@ jobs:
       pull-requests: write
 
   component-descriptor:
-    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'reviewed/ok-to-test' }}
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'ok-to-test' }}
     uses: gardener/cc-utils/.github/workflows/post-build.yaml@master
     needs:
       - build


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
/kind cleanup
With this PR one should use the label `ok-to-test` to allow testing to be started when PRs are opened by external contributors.
Related to https://github.com/gardener/cc-utils/pull/1512
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
