### PR TITLE
Use org variable for ok-to-test label

### DIFF
--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'ok-to-test' }}
+    if: ${{ github.event.action != 'labeled' || (github.event.label.name == vars.DEFAULT_LABEL_OK_TO_TEST && vars.DEFAULT_LABEL_OK_TO_TEST != '') }}
     uses: ./.github/workflows/build.yaml
     with:
       mode: snapshot
@@ -21,7 +21,7 @@ jobs:
       pull-requests: write
 
   component-descriptor:
-    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'ok-to-test' }}
+    if: ${{ github.event.action != 'labeled' || (github.event.label.name == vars.DEFAULT_LABEL_OK_TO_TEST && vars.DEFAULT_LABEL_OK_TO_TEST != '') }}
     uses: gardener/cc-utils/.github/workflows/post-build.yaml@master
     needs:
       - build


### PR DESCRIPTION
/kind cleanup
With this PR one should use the label `ok-to-test` to allow testing to be started when PRs are opened by external contributors.
The label is configured as a variable for the gardener org.
Related to https://github.com/gardener/cc-utils/pull/1512